### PR TITLE
Fix bug on naive grpo id

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -711,8 +711,8 @@ class RayPPOTrainer(object):
                     if not self.config.do_search:
                         gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
 
-                        batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                                dtype=object)
+                        batch.non_tensor_batch['uid'] = batch.non_tensor_batch['index'].copy()
+
                         # repeat to align with repeated responses in rollout
                         batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                         batch = batch.union(gen_batch_output)


### PR DESCRIPTION
In the Naive grpo without search, the `batch.non_tensor_batch['uid']= np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
                                                                dtype=object)` construction method results in only one group. It has now been modified to be consistent with the method in the search version `batch.non_tensor_batch['uid'] = batch.non_tensor_batch['index'].copy()`.