### PR TITLE
add reranker to Search-R1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 **/*.tar.gz
 **/playground
 **/wandb
+**/verl_checkpoints
+**/sbatch_jobs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/reranker_launch.sh
+++ b/reranker_launch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+python search_r1/search/reranker_server.py \
+                    --rerank_topk 3 \
+                    --rerank_model_name_or_path "cross-encoder/ms-marco-MiniLM-L12-v2" \
+                    --batch_size 32 \
+                    --reranker_type "sentence_transformer" 

--- a/search_r1/search/reranker.sh
+++ b/search_r1/search/reranker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python 

--- a/search_r1/search/reranker_server.py
+++ b/search_r1/search/reranker_server.py
@@ -1,0 +1,165 @@
+import argparse
+from collections import defaultdict
+from typing import Optional
+from dataclasses import dataclass, field
+
+from sentence_transformers import CrossEncoder
+import torch
+from transformers import HfArgumentParser
+import numpy as np
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+class BaseCrossEncoder:
+    def __init__(self, model, batch_size=32, device="cuda"):
+        self.model = model
+        self.batch_size = batch_size
+        self.model.to(device)
+        
+    def _passage_to_string(self, doc_item):
+        if "document" not in doc_item:
+            content = doc_item['contents']
+        else:
+            content = doc_item['document']['contents']
+        title = content.split("\n")[0]
+        text = "\n".join(content.split("\n")[1:])
+        
+        return f"(Title: {title}) {text}"
+            
+    def rerank(self, 
+               queries: list[str], 
+               documents: list[list[dict]]):
+        """
+        Assume documents is a list of list of dicts, where each dict is a document with keys "id" and "contents".
+        This asumption is made to be consistent with the output of the retrieval server.
+        """ 
+        assert len(queries) == len(documents)
+        
+        pairs = []
+        qids = []
+        for qid, query in enumerate(queries):
+            for document in documents:
+                for doc_item in document:
+                    doc = self._passage_to_string(doc_item)
+                    pairs.append((query, doc))
+                    qids.append(qid)
+                    
+        scores = self._predict(pairs)
+        query_to_doc_scores = defaultdict(list)
+        
+        assert len(scores) == len(pairs) == len(qids)
+        for i in range(len(pairs)):
+            query, doc = pairs[i]
+            score = scores[i] 
+            qid = qids[i]
+            query_to_doc_scores[qid].append((doc, score))
+            
+        sorted_query_to_doc_scores = {}
+        for query, doc_scores in query_to_doc_scores.items():
+            sorted_query_to_doc_scores[query] = sorted(doc_scores, key=lambda x: x[1], reverse=True)
+            
+        return sorted_query_to_doc_scores
+                    
+    def _predict(self, pairs: list[tuple[str, str]]):
+        raise NotImplementedError 
+    
+    @classmethod
+    def load(cls, model_name_or_path, **kwargs):
+        raise NotImplementedError
+    
+    
+class SentenceTransformerCrossEncoder(BaseCrossEncoder):
+    def __init__(self, model, batch_size=32, device="cuda"):
+        super().__init__(model, batch_size, device)
+
+    def _predict(self, pairs: list[tuple[str, str]]):
+        scores = self.model.predict(pairs, batch_size=self.batch_size)
+        scores = scores.tolist() if isinstance(scores, torch.Tensor) or isinstance(scores, np.ndarray) else scores
+        return scores
+    
+    @classmethod
+    def load(cls, model_name_or_path, **kwargs):
+        model = CrossEncoder(model_name_or_path)
+        return cls(model, **kwargs)
+    
+    
+class RerankRequest(BaseModel):
+    queries: list[str]
+    documents: list[list[dict]]
+    rerank_topk: Optional[int] = None
+    return_scores: bool = False
+    
+    
+@dataclass 
+class RerankerArguments:
+    max_length: int = field(default=512)
+    rerank_topk: int = field(default=3)
+    rerank_model_name_or_path: str = field(default="cross-encoder/ms-marco-MiniLM-L12-v2")
+    batch_size: int = field(default=32)
+    reranker_type: str = field(default="sentence_transformer")
+    
+def get_reranker(config):
+    if config.reranker_type == "sentence_transformer":
+        return SentenceTransformerCrossEncoder.load(
+            config.rerank_model_name_or_path,
+            batch_size=config.batch_size,
+            device="cuda" if torch.cuda.is_available() else "cpu"
+        )
+    else:
+        raise ValueError(f"Unknown reranker type: {config.reranker_type}")
+
+
+app = FastAPI()
+
+# 1) Build a config (could also parse from arguments).
+#    In real usage, you'd parse your CLI arguments or environment variables.
+parser = HfArgumentParser((RerankerArguments))
+config = parser.parse_args_into_dataclasses()[0]
+
+# 2) Instantiate a global retriever so it is loaded once and reused.
+reranker = get_reranker(config)
+
+@app.post("/rerank")
+def rerank_endpoint(request: RerankRequest):
+    """
+    Endpoint that accepts queries and performs retrieval.
+    Input format:
+    {
+      "queries": ["What is Python?", "Tell me about neural networks."],
+      "documents": [[doc_item_1, ..., doc_item_k], [doc_item_1, ..., doc_item_k]],
+      "rerank_topk": 3,
+      "return_scores": true
+    }
+    """
+    if not request.rerank_topk:
+        request.rerank_topk = config.rerank_topk  # fallback to default
+
+    # Perform batch re reranking
+    # doc_scores already sorted by score
+    query_to_doc_scores = reranker.rerank(request.queries, request.documents) 
+    
+    # Format response 
+    resp = []
+    for _, doc_scores in query_to_doc_scores.items():
+        doc_scores = doc_scores[:request.rerank_topk]
+        if request.return_scores:
+            combined = [] 
+            for doc, score in doc_scores:
+                combined.append({"document": doc, "score": score})
+            resp.append(combined)
+        else:
+            resp.append([doc for doc, _ in doc_scores])
+    return {"result": resp}
+    
+
+
+if __name__ == "__main__":
+    # 3) Launch the server. By default, it listens on http://127.0.0.1:8000
+    uvicorn.run(app, host="0.0.0.0", port=6980)
+    
+    
+
+        

--- a/search_r1/search/retrieval_request.py
+++ b/search_r1/search/retrieval_request.py
@@ -1,11 +1,11 @@
 import requests
 
 # URL for your local FastAPI server
-url = "http://127.0.0.1:8000/retrieve"
+url = "http://10.100.20.13:8000/retrieve"
 
 # Example payload
 payload = {
-    "queries": ["What is the capital of France?", "Explain neural networks."] * 200,
+    "queries": ["What is the capital of France?", "Explain neural networks."],
     "topk": 5,
     "return_scores": True
 }
@@ -21,3 +21,5 @@ retrieved_data = response.json()
 
 print("Response from server:")
 print(retrieved_data)
+
+# [ {"document": {"id": "xxx", "contents": "yyy"}, "score": "zzz"}}, {}]

--- a/search_r1/search/retrieval_rerank_request.py
+++ b/search_r1/search/retrieval_rerank_request.py
@@ -1,0 +1,42 @@
+import requests
+
+# URL for your local FastAPI server
+retrieval_url = "http://10.100.20.17:8000/retrieve"
+rerank_url = "http://10.100.20.21:6980/rerank"
+
+
+queries = ["What is the capital of France?", "Explain neural networks."]*10
+# Example payload
+retrieval_request = {
+    "queries": queries,
+    "topk": 10,
+    "return_scores": True
+}
+
+# Send POST request
+response = requests.post(retrieval_url, json=retrieval_request)
+
+# Raise an exception if the request failed
+response.raise_for_status()
+
+# Get the JSON response
+retrieved_data = response.json()
+
+print("Response from retirever server:")
+# print(retrieved_data)
+
+rerank_request = {
+    "queries": queries,
+    "documents": retrieved_data["result"],
+    "rerank_topk": 3,
+    "return_scores": True
+}
+
+response = requests.post(rerank_url, json=rerank_request)
+response.raise_for_status()
+rerank_data = response.json()
+response = rerank_data['result']
+print("Response from reranker server:")
+print(len(response))
+# print(response)
+# [ {"document": {"id": "xxx", "contents": "yyy"}, "score": "zzz"}}, {}]

--- a/train_ppo.sh
+++ b/train_ppo.sh
@@ -1,5 +1,6 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export DATA_DIR='data/nq_search'
+export HF_HOME=/gypsum/work1/zamani/hzeng/.cache/huggingface/
 
 WAND_PROJECT='Search-R1'
 
@@ -74,7 +75,7 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
     +trainer.val_only=false \
     +trainer.val_before_train=true \
     trainer.default_hdfs_dir=null \
-    trainer.n_gpus_per_node=8 \
+    trainer.n_gpus_per_node=4 \
     trainer.nnodes=1 \
     trainer.save_freq=100 \
     trainer.test_freq=50 \
@@ -85,6 +86,9 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
     trainer.default_hdfs_dir=null \
     trainer.default_local_dir=verl_checkpoints/$EXPERIMENT_NAME \
     max_turns=2 \
-    retriever.url="http://127.0.0.1:8000/retrieve" \
-    retriever.topk=3 \
+    retriever.url="http://10.100.20.17:8000/retrieve" \
+    retriever.topk=10 \
+    reranker.do_rerank=true \
+    reranker.url="http://10.100.20.21:6980/rerank" \
+    reranker.topk=3 \
     2>&1 | tee $EXPERIMENT_NAME.log

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -146,6 +146,11 @@ retriever:
   url: "http://127.0.0.1:8000/retrieve"
   topk: 3
 
+reranker:
+  do_rerank: False
+  url: "http://127.0.0.1:8000/rerank"
+  topk: 3
+
 algorithm:
   gamma: 1.0
   lam: 1.0

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -452,6 +452,9 @@ class RayPPOTrainer(object):
             no_think_rl=self.config.algorithm.no_think_rl,
             search_url = self.config.retriever.url,
             topk = self.config.retriever.topk,
+            do_rerank=self.config.reranker.do_rerank,
+            rerank_url=self.config.reranker.url,
+            rerank_topk=self.config.reranker.topk,
         )
 
         # Agent config preparation
@@ -683,6 +686,9 @@ class RayPPOTrainer(object):
             no_think_rl=self.config.algorithm.no_think_rl,
             search_url = self.config.retriever.url,
             topk = self.config.retriever.topk,
+            do_rerank=self.config.reranker.do_rerank,
+            rerank_url=self.config.reranker.url,
+            rerank_topk=self.config.reranker.topk,
         )
 
         generation_manager = LLMGenerationManager(


### PR DESCRIPTION


This PR integrates the reranker component into the Search-R1 framework. 

Please make sure `sentence-transformer` is installed in the retriever env, if not, run:
```bash
pip install -U sentence-transformers
```

To launch reranker, run 
```bash
reranker_launch.sh
```

To try the retrieval-reranker toy example, run:
```bash
search/retrieval_rerank_request.py
```



